### PR TITLE
Ensure tests exist in correct module namespace

### DIFF
--- a/.template/solution.rb.erb
+++ b/.template/solution.rb.erb
@@ -2,27 +2,27 @@ require 'minitest/autorun'
 
 require_relative '../../lib/solution_base'
 
-class SolutionTest < Minitest::Test
-  make_my_diffs_pretty!
-
-  def setup
-    @solution = <%= @module_name %>::Solution.new
-  end
-
-  def test_sample
-    assert_output(/Loaded sample input:/) { @solution.sample }
-  end
-
-  def test_part_one
-    assert_output(/Loaded actual input:/) { @solution.part_one }
-  end
-
-  def test_part_two
-    skip 'Not implemented yet'
-  end
-end
-
 module <%= @module_name %>
+  class SolutionTest < Minitest::Test
+    make_my_diffs_pretty!
+
+    def setup
+      @solution = <%= @module_name %>::Solution.new
+    end
+
+    def test_sample
+      assert_output(/Loaded sample input:/) { @solution.sample }
+    end
+
+    def test_part_one
+      assert_output(/Loaded actual input:/) { @solution.part_one }
+    end
+
+    def test_part_two
+      skip 'Not implemented yet'
+    end
+  end
+
   class Solution < SolutionBase
     def sample
       puts 'Loaded sample input:'

--- a/src/day1/solution.rb
+++ b/src/day1/solution.rb
@@ -2,27 +2,27 @@ require 'minitest/autorun'
 
 require_relative '../../lib/solution_base'
 
-class SolutionTest < Minitest::Test
-  make_my_diffs_pretty!
-
-  def setup
-    @solution = Day1::Solution.new
-  end
-
-  def test_sample
-    assert_output(/Loaded sample input:/) { @solution.sample }
-  end
-
-  def test_part_one
-    assert_output(/Loaded actual input:/) { @solution.part_one }
-  end
-
-  def test_part_two
-    skip 'Not implemented yet'
-  end
-end
-
 module Day1
+  class SolutionTest < Minitest::Test
+    make_my_diffs_pretty!
+
+    def setup
+      @solution = Day1::Solution.new
+    end
+
+    def test_sample
+      assert_output(/Loaded sample input:/) { @solution.sample }
+    end
+
+    def test_part_one
+      assert_output(/Loaded actual input:/) { @solution.part_one }
+    end
+
+    def test_part_two
+      skip 'Not implemented yet'
+    end
+  end
+
   class Solution < SolutionBase
     def sample
       puts 'Loaded sample input:'


### PR DESCRIPTION
This fixes a bug when running full suite with `rake test` where an instance var set in `SolutionTest` could pull from Day 1 OR 2 based on random test order.

Nesting this in the correct module resolves the issue.